### PR TITLE
Subtract items in other customers' cart from stock

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,0 +1,7 @@
+module Spree
+  LineItem.class_eval do
+    def sufficient_stock?
+      Stock::QuantifierWithPending.new(variant, order).can_supply? quantity
+    end
+  end
+end

--- a/app/models/spree/stock/availability_validator_decorator.rb
+++ b/app/models/spree/stock/availability_validator_decorator.rb
@@ -1,0 +1,12 @@
+module Spree
+  module Stock
+    AvailabilityValidator.class_eval do
+      def item_available?(line_item, quantity)
+        Stock::QuantifierWithPending.new(
+          line_item.variant,
+          line_item.order
+        ).can_supply?(quantity)
+      end
+    end
+  end
+end

--- a/app/models/spree/stock/quantifier_with_pending.rb
+++ b/app/models/spree/stock/quantifier_with_pending.rb
@@ -1,0 +1,25 @@
+module Spree
+  module Stock
+    class QuantifierWithPending < Quantifier
+      def initialize(variant, current_order = nil)
+        super(variant)
+        @current_order = current_order
+      end
+
+      def total_on_hand
+        [super - total_pending, 0].max
+      end
+
+      private
+
+      def total_pending
+        Spree::Order.
+          incomplete.
+          joins(:line_items).
+          where(Spree::LineItem.table_name => { variant_id: @variant }).
+          where.not(Spree::Order.table_name => { id: @current_order }).
+          sum(:quantity)
+      end
+    end
+  end
+end

--- a/app/models/spree/variant_decorator.rb
+++ b/app/models/spree/variant_decorator.rb
@@ -1,0 +1,11 @@
+module Spree
+  Variant.class_eval do
+    def can_supply?(quantity = 1)
+      Spree::Stock::QuantifierWithPending.new(self).can_supply?(quantity)
+    end
+
+    def total_on_hand
+      Spree::Stock::QuantifierWithPending.new(self).total_on_hand
+    end
+  end
+end

--- a/spec/features/customer_checkouts_spec.rb
+++ b/spec/features/customer_checkouts_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Customer checkouts" do
   before do
     shipping_method.calculator.update!(preferred_amount: 10)
     product.shipping_category = shipping_method.shipping_categories.first
+    product.master.stock_items.first.update!(backorderable: false)
     product.save!
   end
 
@@ -23,6 +24,32 @@ RSpec.feature "Customer checkouts" do
     select_payment_method
 
     expect(page).to have_content("Your order has been processed successfully")
+  end
+
+  scenario "adding item to cart reserves the item" do
+    order = create(:order, state: "cart")
+    create(:line_item, order: order, product: product, quantity: 10)
+
+    visit spree.root_path
+    click_on product.name
+    expect(page).to have_content("Out of Stock")
+
+    click_button "Add To Cart"
+
+    expect(page).to have_content("not available")
+  end
+
+  scenario "adjusting quantity in cart takes reservation into account" do
+    order = create(:order, state: "cart")
+    create(:line_item, order: order, product: product, quantity: 9)
+
+    visit spree.root_path
+    click_on product.name
+    click_button "Add To Cart"
+    fill_in line_item_quantity_field, with: "2"
+    click_button "Update"
+
+    expect(page).to have_content("not available")
   end
 
   def fill_in_guest_checkout_details
@@ -54,5 +81,9 @@ RSpec.feature "Customer checkouts" do
   def select_payment_method
     choose payment_method.name
     click_button "Save and Continue"
+  end
+
+  def line_item_quantity_field
+    find(".line-item:first .cart-item-quantity input")["id"]
   end
 end

--- a/spec/features/customer_checkouts_spec.rb
+++ b/spec/features/customer_checkouts_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+RSpec.feature "Customer checkouts" do
+  let!(:product) { create(:product_in_stock) }
+  let!(:shipping_method) { create(:shipping_method) }
+  let!(:payment_method) { create(:check_payment_method) }
+  let!(:store) { create(:store) }
+
+  before do
+    shipping_method.calculator.update!(preferred_amount: 10)
+    product.shipping_category = shipping_method.shipping_categories.first
+    product.save!
+  end
+
+  scenario "proceed successfully", :js do
+    visit spree.root_path
+    click_on product.name
+    click_button "Add To Cart"
+    click_button "Checkout"
+    fill_in_guest_checkout_details
+    fill_in_billing_information
+    select_shipping_method
+    select_payment_method
+
+    expect(page).to have_content("Your order has been processed successfully")
+  end
+
+  def fill_in_guest_checkout_details
+    within "#guest_checkout" do
+      fill_in "Email", with: "customer@example.com"
+      click_button "Continue"
+    end
+  end
+
+  def fill_in_billing_information
+    within "#billing" do
+      fill_in "First Name", with: "John"
+      fill_in "Last Name", with: "Doe"
+      fill_in "Street Address", with: "123 Some Street"
+      fill_in "City", with: "Montgomery"
+      fill_in "Zip", with: "36101"
+      select "Alabama"
+      fill_in "Phone", with: "123-456-7890"
+    end
+
+    click_button "Save and Continue"
+  end
+
+  def select_shipping_method
+    choose shipping_method.name
+    click_button "Save and Continue"
+  end
+
+  def select_payment_method
+    choose payment_method.name
+    click_button "Save and Continue"
+  end
+end

--- a/spec/models/spree/line_item_spec.rb
+++ b/spec/models/spree/line_item_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe Spree::LineItem do
+  describe "#sufficient_stock?" do
+    it "uses Stock::QuantifierWithPending" do
+      variant = build_stubbed(:variant)
+      order = build_stubbed(:order)
+      can_supply_result = Object.new
+      quantifier = instance_double(
+        Spree::Stock::QuantifierWithPending,
+        can_supply?: can_supply_result
+      )
+      allow(Spree::Stock::QuantifierWithPending).
+        to receive(:new).and_return(quantifier)
+      line_item = build(:line_item, variant: variant, order: order, quantity: 1)
+
+      result = line_item.sufficient_stock?
+
+      expect(result).to eq can_supply_result
+      expect(Spree::Stock::QuantifierWithPending).
+        to have_received(:new).with(variant, order)
+      expect(quantifier).to have_received(:can_supply?).with(1)
+    end
+  end
+end

--- a/spec/models/spree/stock/availability_validator_spec.rb
+++ b/spec/models/spree/stock/availability_validator_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Spree::Stock::AvailabilityValidator do
+  describe "#item_available?" do
+    it "uses Stock::QuantifierWithPending" do
+      variant = build_stubbed(:variant)
+      order = build_stubbed(:order)
+      can_supply_result = Object.new
+      quantifier = instance_double(
+        Spree::Stock::QuantifierWithPending,
+        can_supply?: can_supply_result
+      )
+      allow(Spree::Stock::QuantifierWithPending).
+        to receive(:new).and_return(quantifier)
+      line_item = build(:line_item, variant: variant, order: order)
+      validator = Spree::Stock::AvailabilityValidator.new
+
+      result = validator.item_available?(line_item, 1)
+
+      expect(result).to eq can_supply_result
+      expect(Spree::Stock::QuantifierWithPending).
+        to have_received(:new).with(variant, order)
+      expect(quantifier).to have_received(:can_supply?).with(1)
+    end
+  end
+end

--- a/spec/models/spree/stock/quantifier_with_pending_spec.rb
+++ b/spec/models/spree/stock/quantifier_with_pending_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe Spree::Stock::QuantifierWithPending do
+  let(:product) { create(:product_in_stock) }
+  let(:variant) { product.master }
+
+  before do
+    variant.stock_items.first.set_count_on_hand(10)
+  end
+
+  describe "#total_on_hand" do
+    context "without giving a pending order" do
+      it "returns remaining stock including reservations in customers' cart" do
+        create_pending_order(quantity: 1)
+        create_pending_order(quantity: 2)
+        quantifier = Spree::Stock::QuantifierWithPending.new(variant)
+
+        expect(quantifier.total_on_hand).to eq 7
+      end
+
+      it "does not return negative number" do
+        create_pending_order(quantity: 11)
+        quantifier = Spree::Stock::QuantifierWithPending.new(variant)
+
+        expect(quantifier.total_on_hand).to eq 0
+      end
+    end
+
+    context "with a pending order" do
+      it "returns remaining stock with reservation but exclude current order" do
+        order = create_pending_order(quantity: 1)
+        create_pending_order(quantity: 2)
+        quantifier = Spree::Stock::QuantifierWithPending.new(variant, order)
+
+        expect(quantifier.total_on_hand).to eq 8
+      end
+    end
+  end
+
+  def create_pending_order(quantity:)
+    create(:order, state: "cart").tap do |order|
+      create(:line_item, order: order, product: product, quantity: quantity)
+    end
+  end
+end

--- a/spec/models/spree/variant_spec.rb
+++ b/spec/models/spree/variant_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Spree::Variant do
+  describe "#can_supply?" do
+    it "uses Stock::QuantifierWithPending" do
+      quantifier = instance_double(
+        Spree::Stock::QuantifierWithPending,
+        can_supply?: true
+      )
+      allow(Spree::Stock::QuantifierWithPending).
+        to receive(:new).and_return(quantifier)
+      variant = build(:variant)
+
+      variant.can_supply?(1)
+
+      expect(Spree::Stock::QuantifierWithPending).
+        to have_received(:new).with(variant)
+      expect(quantifier).to have_received(:can_supply?).with(1)
+    end
+  end
+
+  describe "#total_on_hand" do
+    it "uses Stock::QuantifierWithPending" do
+      quantifier = instance_double(
+        Spree::Stock::QuantifierWithPending,
+        total_on_hand: 10
+      )
+      allow(Spree::Stock::QuantifierWithPending).
+        to receive(:new).and_return(quantifier)
+      variant = build(:variant)
+
+      expect(variant.total_on_hand).to eq 10
+      expect(Spree::Stock::QuantifierWithPending).
+        to have_received(:new).with(variant)
+      expect(quantifier).to have_received(:total_on_hand)
+    end
+  end
+end

--- a/spec/support/capybara_webkit.rb
+++ b/spec/support/capybara_webkit.rb
@@ -1,0 +1,2 @@
+require "capybara/webkit"
+Capybara.javascript_driver = :webkit

--- a/spree_queue_line.gemspec
+++ b/spree_queue_line.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 3.0.4'
 
   s.add_development_dependency 'capybara', '~> 2.4'
+  s.add_development_dependency 'capybara-webkit'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_girl', '~> 4.5'


### PR DESCRIPTION
First part of reservation feature.

This is done by counting all items that are orders that are incomplete and subtract it from in-hand count. Note that this already take current customer's cart into account, meaning that their order should process successfully even though it blocks other users from making a purchase.