### PR TITLE
Add a job to expire customer's order in 20 minutes

### DIFF
--- a/app/jobs/pending_order_cleanup_job.rb
+++ b/app/jobs/pending_order_cleanup_job.rb
@@ -1,0 +1,9 @@
+class PendingOrderCleanupJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(order, timestamp)
+    if order.updated_at.to_i == timestamp && !order.completed?
+      order.empty!
+    end
+  end
+end

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,13 @@
+module Spree
+  Order.class_eval do
+    after_save :enqueue_order_expiring_job
+
+    private
+
+    def enqueue_order_expiring_job
+      PendingOrderCleanupJob.
+        set(wait: 20.minutes).
+        perform_later(self, updated_at.to_i)
+    end
+  end
+end

--- a/spec/features/customer_checkouts_spec.rb
+++ b/spec/features/customer_checkouts_spec.rb
@@ -1,17 +1,7 @@
 require "spec_helper"
 
 RSpec.feature "Customer checkouts" do
-  let!(:product) { create(:product_in_stock) }
-  let!(:shipping_method) { create(:shipping_method) }
-  let!(:payment_method) { create(:check_payment_method) }
-  let!(:store) { create(:store) }
-
-  before do
-    shipping_method.calculator.update!(preferred_amount: 10)
-    product.shipping_category = shipping_method.shipping_categories.first
-    product.master.stock_items.first.update!(backorderable: false)
-    product.save!
-  end
+  include CheckoutHelpers
 
   scenario "proceed successfully", :js do
     visit spree.root_path
@@ -50,37 +40,6 @@ RSpec.feature "Customer checkouts" do
     click_button "Update"
 
     expect(page).to have_content("not available")
-  end
-
-  def fill_in_guest_checkout_details
-    within "#guest_checkout" do
-      fill_in "Email", with: "customer@example.com"
-      click_button "Continue"
-    end
-  end
-
-  def fill_in_billing_information
-    within "#billing" do
-      fill_in "First Name", with: "John"
-      fill_in "Last Name", with: "Doe"
-      fill_in "Street Address", with: "123 Some Street"
-      fill_in "City", with: "Montgomery"
-      fill_in "Zip", with: "36101"
-      select "Alabama"
-      fill_in "Phone", with: "123-456-7890"
-    end
-
-    click_button "Save and Continue"
-  end
-
-  def select_shipping_method
-    choose shipping_method.name
-    click_button "Save and Continue"
-  end
-
-  def select_payment_method
-    choose payment_method.name
-    click_button "Save and Continue"
   end
 
   def line_item_quantity_field

--- a/spec/features/expiring_cart_spec.rb
+++ b/spec/features/expiring_cart_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe "Expiring cart" do
+  include CheckoutHelpers
+  include ActiveSupport::Testing::TimeHelpers
+
+  scenario "removes item from customer's cart after 20 minutes" do
+    visit spree.root_path
+    click_on product.name
+    click_button Spree.t(:add_to_cart)
+
+    travel_to 21.minutes.from_now do
+      perform_enqueued_jobs
+
+      visit spree.cart_path
+      expect(page).to have_no_content(product.name)
+    end
+  end
+
+  scenario "does not remove items from completed order", :js do
+    visit spree.root_path
+    click_on product.name
+    click_button Spree.t(:add_to_cart)
+    click_button Spree.t(:checkout)
+    fill_in_guest_checkout_details
+    fill_in_billing_information
+    select_shipping_method
+    select_payment_method
+
+    expect(page).to have_content Spree.t(:order_processed_successfully)
+
+    travel_to 21.minutes.from_now do
+      perform_enqueued_jobs
+
+      visit current_path
+      expect(page).to have_content(product.name)
+    end
+  end
+
+  def perform_enqueued_jobs
+    ActiveJob::Base.queue_adapter.enqueued_jobs.each do |payload|
+      if payload[:at].nil? || Time.current.to_f >= payload[:at]
+        payload[:job].
+          new(*ActiveJob::Arguments.deserialize(payload[:args])).
+          perform_now
+      end
+    end
+  end
+end

--- a/spec/jobs/pending_order_cleanup_job_spec.rb
+++ b/spec/jobs/pending_order_cleanup_job_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe PendingOrderCleanupJob, type: :job do
+  it "clear items from order" do
+    order = create(:order_with_line_items, state: "cart")
+
+    PendingOrderCleanupJob.perform_now(order, order.updated_at.to_i)
+
+    expect(order.reload.line_items).to be_empty
+  end
+
+  it "does not clear items if timestamp does not match" do
+    order = create(:order_with_line_items, state: "cart")
+
+    PendingOrderCleanupJob.perform_now(order, 20.minutes.ago.to_i)
+
+    expect(order.reload.line_items).not_to be_empty
+  end
+
+  it "does not clear items if order is completed" do
+    order = create(:completed_order_with_totals, state: "complete")
+
+    PendingOrderCleanupJob.perform_now(order, order.updated_at.to_i)
+
+    expect(order.reload.line_items).not_to be_empty
+  end
+end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe Spree::Order do
+  it "enqueues PendingOrderCleanupJob when order is created" do
+    job = spy(:job)
+    allow(PendingOrderCleanupJob).to receive(:set).and_return(job)
+
+    order = create(:order, state: "cart")
+
+    expect(PendingOrderCleanupJob).to have_received(:set).with(wait: 20.minutes)
+    expect(job).
+      to have_received(:perform_later).with(order, order.updated_at.to_i)
+  end
+
+  it "enqueues PendingOrderCleanupJob when order is updated" do
+    order = create(:order, state: "cart")
+    job = spy(:job)
+    allow(PendingOrderCleanupJob).to receive(:set).and_return(job)
+
+    order.save!
+
+    expect(PendingOrderCleanupJob).to have_received(:set).with(wait: 20.minutes)
+    expect(job).
+      to have_received(:perform_later).with(order, order.updated_at.to_i)
+  end
+end

--- a/spec/support/active_job.rb
+++ b/spec/support/active_job.rb
@@ -1,0 +1,8 @@
+Rails.configuration.active_job.queue_adapter = :test
+
+RSpec.configure do |config|
+  config.before do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+    ActiveJob::Base.queue_adapter.performed_jobs.clear
+  end
+end

--- a/spec/support/checkout_helpers.rb
+++ b/spec/support/checkout_helpers.rb
@@ -1,0 +1,46 @@
+module CheckoutHelpers
+  def self.included(klass)
+    klass.let!(:product) { create(:product_in_stock) }
+    klass.let!(:shipping_method) { create(:shipping_method) }
+    klass.let!(:payment_method) { create(:check_payment_method) }
+    klass.let!(:store) { create(:store) }
+
+    klass.before do
+      shipping_method.calculator.update!(preferred_amount: 10)
+      product.shipping_category = shipping_method.shipping_categories.first
+      product.master.stock_items.first.update!(backorderable: false)
+      product.save!
+    end
+  end
+
+  def fill_in_guest_checkout_details
+    within "#guest_checkout" do
+      fill_in Spree.t(:email), with: "customer@example.com"
+      click_button Spree.t(:continue)
+    end
+  end
+
+  def fill_in_billing_information
+    within "#billing" do
+      fill_in Spree.t(:first_name), with: "John"
+      fill_in Spree.t(:last_name), with: "Doe"
+      fill_in Spree.t(:street_address), with: "123 Some Street"
+      fill_in Spree.t(:city), with: "Montgomery"
+      fill_in Spree.t(:zip), with: "36101"
+      select Spree::State.first.name
+      fill_in Spree.t(:phone), with: "123-456-7890"
+    end
+
+    click_button Spree.t(:save_and_continue)
+  end
+
+  def select_shipping_method
+    choose shipping_method.name
+    click_button Spree.t(:save_and_continue)
+  end
+
+  def select_payment_method
+    choose payment_method.name
+    click_button Spree.t(:save_and_continue)
+  end
+end


### PR DESCRIPTION
This is done via Active Job API. The job will be queued to run in 20 minutes after user modified the order (adding item to cart, going through checkout flow, etc).

If the user modifies the after the job is queued, the job will become stale and it will do nothing with the order once the job executes. Also, if the order completes, the job will become stale as well.