### PR TITLE
Add Delayed::Job to dummy application

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,14 @@ desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'spree_queue_line'
   Rake::Task['extension:test_app'].invoke
+
+  # Add Active Job configuration for dummy app
+  unless File.exist?("config/initializers/active_job.rb")
+    File.open("config/initializers/active_job.rb", "w") do |file|
+      file.write "Rails.configuration.active_job.queue_adapter = :delayed_job"
+    end
+
+    sh "bin/rails", "generate", "delayed_job:active_record"
+    sh "bin/rake", "db:migrate"
+  end
 end

--- a/spree_queue_line.gemspec
+++ b/spree_queue_line.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara-webkit"
   s.add_development_dependency "coffee-rails"
   s.add_development_dependency "database_cleaner"
+  s.add_development_dependency "delayed_job_active_record"
   s.add_development_dependency "factory_girl", "~> 4.5"
   s.add_development_dependency "ffaker"
   s.add_development_dependency "rspec-rails",  "~> 3.1"


### PR DESCRIPTION
We need an Active Job handler that supports delay execution for dummy application so it will not raise error when order is created.