### PR TITLE
Add rake task to cleanup expired carts

### DIFF
--- a/lib/spree_queue_line/engine.rb
+++ b/lib/spree_queue_line/engine.rb
@@ -16,5 +16,7 @@ module SpreeQueueLine
     end
 
     config.to_prepare &method(:activate).to_proc
+
+    rake_tasks { load "tasks/cleanup.rake" }
   end
 end

--- a/lib/spree_queue_line/factories.rb
+++ b/lib/spree_queue_line/factories.rb
@@ -5,5 +5,13 @@ FactoryGirl.modify do
       email { generate(:random_email) }
       guest_token { SecureRandom.hex }
     end
+
+  end
+
+  factory :order_with_line_items do
+    after(:create) do |order, evaluator|
+      order.updater.update_item_count
+      order.updater.update
+    end
   end
 end

--- a/lib/spree_queue_line/orders_cleaner.rb
+++ b/lib/spree_queue_line/orders_cleaner.rb
@@ -1,0 +1,15 @@
+module SpreeQueueLine
+  class OrdersCleaner
+    def self.perform
+      new.perform
+    end
+
+    def perform
+      Spree::Order.
+        incomplete.
+        where("created_at < ?", 1.day.ago).
+        where(item_count: 0).
+        destroy_all
+    end
+  end
+end

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,8 @@
+require "spree_queue_line/orders_cleaner"
+
+namespace :spree do
+  desc "Remove stale empty orders from the database"
+  task remove_stale_orders: :environment do
+    SpreeQueueLine::OrdersCleaner.perform
+  end
+end

--- a/spec/orders_cleaner_spec.rb
+++ b/spec/orders_cleaner_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "spree_queue_line/orders_cleaner"
+
+RSpec.describe SpreeQueueLine::OrdersCleaner do
+  describe ".perform" do
+    it "Remove empty orders that are not completed 24 hours ago" do
+      _old_empty_order = create(:order, created_at: 1.day.ago)
+      non_empty_order = create(:order_with_line_items, created_at: 1.day.ago)
+      new_empty_order = create(:order)
+
+      SpreeQueueLine::OrdersCleaner.perform
+
+      expect(Spree::Order.order(:id).all).
+        to eq [non_empty_order, new_empty_order]
+    end
+  end
+end


### PR DESCRIPTION
This task will look for orders that has not been completed and has nothing in its cart. It will call #destroy on those orders to remove them from the database.