### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/spree_queue_line.gemspec
+++ b/spree_queue_line.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ffaker"
   s.add_development_dependency "rspec-rails",  "~> 3.1"
   s.add_development_dependency "sass-rails", "~> 5.0.0.beta1"
-  s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
We use capybara-webkit instead of selenium-webdriver for JS testing.