### PR TITLE
Add spree_notifications migrations to generator

### DIFF
--- a/lib/generators/spree_queue_line/install/install_generator.rb
+++ b/lib/generators/spree_queue_line/install/install_generator.rb
@@ -4,17 +4,8 @@ module SpreeQueueLine
 
       class_option :auto_run_migrations, :type => :boolean, :default => false
 
-      def add_javascripts
-        append_file 'vendor/assets/javascripts/spree/frontend/all.js', "//= require spree/frontend/spree_queue_line\n"
-        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_queue_line\n"
-      end
-
-      def add_stylesheets
-        inject_into_file 'vendor/assets/stylesheets/spree/frontend/all.css', " *= require spree/frontend/spree_queue_line\n", :before => /\*\//, :verbose => true
-        inject_into_file 'vendor/assets/stylesheets/spree/backend/all.css', " *= require spree/backend/spree_queue_line\n", :before => /\*\//, :verbose => true
-      end
-
       def add_migrations
+        run 'bundle exec rake railties:install:migrations FROM=spree_notifications'
         run 'bundle exec rake railties:install:migrations FROM=spree_queue_line'
       end
 


### PR DESCRIPTION
Since this gem requires spree_notifications internally, we should
install migrations that are from spree_notifications as well.